### PR TITLE
Add command line flags for tags and attributes.

### DIFF
--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -100,7 +100,7 @@ class ConfigExtractor(Karton):
             config,
             modules=args.modules,
             result_tags=args.tag,
-            attributes=dict(attributes),
+            result_attributes=dict(attributes),
         )
         service.loop()
 

--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -109,7 +109,7 @@ class ConfigExtractor(Karton):
         config: Config,
         modules: str,
         result_tags: List[str],
-        attributes: Dict[str, List[str]],
+        result_attributes: Dict[str, List[str]],
     ) -> None:
         """
         Create instance of the ConfigExtractor.

--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -6,8 +6,8 @@ import os
 import re
 import tempfile
 import zipfile
-from collections import namedtuple, defaultdict
-from typing import List, Dict, DefaultDict
+from collections import defaultdict, namedtuple
+from typing import DefaultDict, Dict, List
 
 from karton.core import Config, Karton, Resource, Task
 from karton.core.resource import ResourceBase

--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -92,7 +92,7 @@ class ConfigExtractor(Karton):
 
         attributes: DefaultDict[str, List[str]] = defaultdict(list)
         for attr in args.attribute:
-            key, value = attr.split("=")
+            key, value = attr.split("=", 1)
             attributes[key].append(value)
 
         config = Config(args.config_file)

--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -116,13 +116,13 @@ class ConfigExtractor(Karton):
 
         :param config: Karton configuration object
         :param modules: Path to a directory with malduck modules.
-        :param result_tags: Tags that should be applied to all produced configs.
-        :param attributes: Attributes that should be applied to all produced configs.
+        :param result_tags: Tags to be applied to all produced configs.
+        :param result_attributes: Attributes to be applied to all produced configs.
         """
         super().__init__(config)
         self.modules = ExtractorModules(modules)
         self.result_tags = result_tags
-        self.attributes = attributes
+        self.result_attributes = result_attributes
 
     def report_config(self, config, sample, parent=None):
         legacy_config = dict(config)
@@ -160,7 +160,7 @@ class ConfigExtractor(Karton):
                 "sample": sample,
                 "parent": parent or sample,
                 "tags": self.result_tags,
-                "attributes": self.attributes,
+                "attributes": self.result_attributes,
             },
         )
         self.send_task(task)

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(
     packages=["karton.config_extractor"],
     install_requires=open("requirements.txt").read().splitlines(),
     entry_points={
-        'console_scripts': [
-            'karton-config-extractor=karton.config_extractor:ConfigExtractor.main'
+        "console_scripts": [
+            "karton-config-extractor=karton.config_extractor:ConfigExtractor.main"
         ],
     },
     classifiers=[


### PR DESCRIPTION
Sometimes it's useful to automatically add tags and attributes to newly
processed samples. A specific use case is to give a proper attribution
when modules are from external source.

This change adds command line flags like `--tag` and `--attribute` to
facilitate this.