### PR TITLE
adds support for loading malduck modules from the Karton S3 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,9 @@ $ pip install karton-config-extractor
 
 $ karton-config-extractor --modules malduck-extractor-modules/
 ```
+or if your malduck modules are in your Karton S3 storage (MinIO)
+```shell
+$ karton-config-extractor --modules malduck-extractor-modules --S3 True
+```
 
 ![Co-financed by the Connecting Europe Facility by of the European Union](https://www.cert.pl/wp-content/uploads/2019/02/en_horizontal_cef_logo-1.png)

--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -5,11 +5,11 @@ import json
 import os
 from collections import defaultdict, namedtuple
 from typing import DefaultDict, Dict, List, Optional
-from minio import Minio
 
 from karton.core import Config, Karton, Resource, Task
 from karton.core.resource import ResourceBase
 from malduck.extractor import ExtractManager, ExtractorModules
+from minio import Minio
 
 from .__version__ import __version__
 


### PR DESCRIPTION
In some situations it can be helpful to load malduck modules from the Karton S3 storage instead of mapping a volume to the docker container (for example if you deploy the Karton ecosystem on OpenShift).

Maybe my solution has room for improvement:-)

What do you think?