### PR TITLE
Fix blob overwrite issue

### DIFF
--- a/karton/config_extractor/util.py
+++ b/karton/config_extractor/util.py
@@ -39,7 +39,9 @@ def config_dhash(obj: Any) -> str:
         if isinstance(value, dict) and list(value.keys()) == ["in-blob"]:
             in_blob = value["in-blob"]
             if isinstance(in_blob, dict):
-                config[key]["in-blob"] = hashlib.sha256(
-                    convert_to_utf8(in_blob["content"])
-                ).hexdigest()
+                config[key] = {
+                    "in-blob": hashlib.sha256(
+                        convert_to_utf8(in_blob["content"])
+                    ).hexdigest()
+                }
     return _eval_config_dhash(config)


### PR DESCRIPTION
Due to how dict shallow copying in python works, current `config_dhash` overwrites some parts of inputted configs which results in incorrect outgoing tasks:

```
    "payload": {
        "attributes": {},
        "config": {
...
            "raw_cfg": {
                "in-blob": "b53ab16987a814453b1771b9a2b34c3b3cae6fe068883a9d794bb44dc0d047b5"
            },
            "type": "agenttesla"
        },
```