### PR TITLE
WIP: Prepare for karton5 migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 WORKDIR /app/service
 COPY ./requirements.txt ./requirements.txt

--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -258,7 +258,7 @@ class ConfigExtractor(Karton):
 
         self.log.info("done analysing, results: {}".format(json.dumps(results)))
 
-    def process(self, task: Task) -> None:  # type: ignore
+    def process(self, task: Task) -> None:
         sample = task.get_resource("sample")
         headers = task.headers
 

--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -81,10 +81,6 @@ class ConfigExtractor(Karton):
             default=[],
             nargs="+",
         )
-        parser.add_argument(
-            "--identity",
-            help="Override the default Karton identity",
-        )
         return parser
 
     @classmethod
@@ -100,7 +96,6 @@ class ConfigExtractor(Karton):
         config = Config(args.config_file)
         service = ConfigExtractor(
             config,
-            identity=args.identity,
             modules=args.modules,
             result_tags=args.tag,
             result_attributes=dict(attributes),
@@ -110,7 +105,6 @@ class ConfigExtractor(Karton):
     def __init__(
         self,
         config: Config,
-        identity: Optional[str],
         modules: str,
         result_tags: List[str],
         result_attributes: Dict[str, List[str]],
@@ -119,17 +113,10 @@ class ConfigExtractor(Karton):
         Create instance of the ConfigExtractor.
 
         :param config: Karton configuration object
-        :param identity: Override the default Karton identity.
         :param modules: Path to a directory with malduck modules.
         :param result_tags: Tags to be applied to all produced configs.
         :param result_attributes: Attributes to be applied to all produced configs.
         """
-
-        # Identity must be overriden before the super() call, because parent
-        # constructor uses implicit default identity (from the class field).
-        if identity is not None:
-            self.identity = identity
-
         super().__init__(config)
 
         self.modules = ExtractorModules(modules)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-karton-core>=4.2.0,<5.0.0
+karton-core>=5.0.0,<6.0.0
 malduck>=4.2.0,<5.0.0


### PR DESCRIPTION
Since the `--identitiy` argument is added in karton==5.0.0 we no longer need it here