### PR TITLE
Add missing linux dependencies

### DIFF
--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -59,6 +59,30 @@ class ConfigExtractor(Karton):
             "kind": "runnable",
             "platform": "linux",
         },
+        {
+            "type": "sample",
+            "stage": "recognized",
+            "kind": "runnable",
+            "platform": "freebsd",
+        },
+        {
+            "type": "sample",
+            "stage": "recognized",
+            "kind": "runnable",
+            "platform": "netbsd",
+        },
+        {
+            "type": "sample",
+            "stage": "recognized",
+            "kind": "runnable",
+            "platform": "openbsd",
+        },
+        {
+            "type": "sample",
+            "stage": "recognized",
+            "kind": "runnable",
+            "platform": "solaris",
+        },
         {"type": "analysis"},
     ]
 


### PR DESCRIPTION
Following this change in karton-classifier: https://github.com/CERT-Polska/karton-classifier/pull/55. In older classifier versions all ELF were basically `platform: linux` so there was no problem, but the current filters only allow for extraction from `GNU/Linux` ELF files and misses any other ELF from a different platform.

Another option: leave the linux one for backwards compatibility and add only one new filter for `extension: elf`. Leaving for the maintainers to choose the appropriate one :)