### PR TITLE
Bump karton-core to v5.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-karton-core>=5.0.0,<6.0.0
+karton-core>=5.3.4,<6.0.0
 malduck>=4.3.2,<5.0.0


### PR DESCRIPTION
It is a good practice to use config extractor with task timeout. v5.3.4 is the latest known, fixed version where this feature is actually working properly.