### PR TITLE
Add hash to sample type tasks

### DIFF
--- a/karton/config_extractor/config_extractor.py
+++ b/karton/config_extractor/config_extractor.py
@@ -316,7 +316,7 @@ class ConfigExtractor(Karton):
         headers = task.headers
 
         if headers["type"] == "sample":
-            self.log.info("Analyzing original binary")
+            self.log.info(f"Analyzing original binary: {sample.sha256}")
             self.analyze_sample(task, sample)
         elif headers["type"] == "analysis":
             sample_hash = hashlib.sha256(sample.content or b"").hexdigest()


### PR DESCRIPTION
Hey!

We noticed that in some instances the analysis of the binary is stuck for whatever reason. This should help to at least identify the sample that caused the karton to hang